### PR TITLE
feat: add social sharing buttons to tools index page

### DIFF
--- a/PresentationLayer/Views/Tools/Index.cshtml
+++ b/PresentationLayer/Views/Tools/Index.cshtml
@@ -5,6 +5,20 @@
 <div class="jumbotron text-center bg-light py-5 container">
     <h1 class="display-4">@Model.Name</h1>
     <p class="lead">@Model.Description</p>
+    <hr class="my-2" />
+
+    <div class="d-flex align-items-center gap-2 justify-content-center">
+        <button class="btn text-danger" style="font-size: 2rem;">
+            <i class="bi bi-heart"></i>
+        </button>
+        <span class=" me-3">or share on</span>
+        <a href="#" target="_blank" class="btn btn-primary">
+            <i class="bi bi-facebook"></i> Facebook
+        </a>
+        <a href="#" target="_blank" class="btn btn-dark">
+            <i class="bi bi-twitter-x"></i> X
+        </a>
+    </div>
 </div>
 
 <hr class="my-4" />


### PR DESCRIPTION
Add social sharing buttons for Facebook and X to the tools index page.  
Enhance user engagement by providing options to share content easily.  
Include a heart button for favoriting, improving the overall user  
experience and interaction with the tools presented.