### PR TITLE
feat(search): add search page with filtering and pagination

### DIFF
--- a/PresentationLayer/Controllers/SearchController.cs
+++ b/PresentationLayer/Controllers/SearchController.cs
@@ -1,0 +1,48 @@
+﻿using BusinessLayer.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using PresentationLayer.Models.Tool;
+
+namespace PresentationLayer.Controllers
+{
+    public class SearchController(IUnitOfWork _unitOfWork, ILogger<AuthController> logger) : Controller
+    {
+        public IActionResult Index(string searchTerm = "", int groupId = 0, int page = 1)
+        {
+            int pageSize = 10;
+
+            var toolsQuery = _unitOfWork.Tools.GetAllWithGroup()
+                .AsQueryable();
+
+            if (!string.IsNullOrEmpty(searchTerm))
+            {
+                toolsQuery = toolsQuery.Where(t => t.Name.ToLower().Contains(searchTerm.ToLower()));
+            }
+
+            if (groupId != 0)
+            {
+                toolsQuery = toolsQuery.Where(t => t.GroupId == groupId);
+            }
+
+            var tools = toolsQuery
+                .Where(t => !t.IsDisabled)
+                .OrderBy(t => t.ToolId)
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .ToList();
+
+            var totalToolsCount = toolsQuery.Count();
+
+            var model = new ToolsViewModel
+            {
+                Tools = tools,
+                Groups = _unitOfWork.Groups.GetAll().ToList(),
+                CurrentSearchTerm = searchTerm,
+                CurrentGroupId = groupId,
+                CurrentPage = page,
+                TotalPages = (int)Math.Ceiling((double)totalToolsCount / pageSize)
+            };
+
+            return View(model);
+        }
+    }
+}

--- a/PresentationLayer/Views/Admin/Tools.cshtml
+++ b/PresentationLayer/Views/Admin/Tools.cshtml
@@ -113,6 +113,20 @@
         <div class="d-flex justify-content-center">
             <nav aria-label="Active Tools Page navigation">
                 <ul class="pagination">
+                    @if (Model.CurrentPage > 1)
+                    {
+                                <li class="page-item">
+                                                <a class="page-link" href="@Url.Action("Tools", "Admin", new { tab = "active", page = Model.CurrentPage - 1, searchTerm = Model.CurrentSearchTerm, groupId = Model.CurrentGroupId })" aria-label="Previous">
+                                        <span aria-hidden="true">&lt;</span>
+                                    </a>
+                                </li>
+                    }
+                    else
+                    {
+                                <li class="page-item disabled">
+                                    <span class="page-link" aria-hidden="true">&lt;</span>
+                                </li>
+                    }
                     @for (var i = 1; i <= Model.TotalPages; i++)
                     {
                         @if (i == Model.CurrentPage)
@@ -127,6 +141,21 @@
                                 <a class="page-link" href="@Url.Action("Tools", "Admin", new { tab = "active", page = i, searchTerm = Model.CurrentSearchTerm, groupId = Model.CurrentGroupId })">@i</a>
                             </li>
                         }
+                    }
+
+                    @if (Model.CurrentPage < Model.TotalPages)
+                    {
+                                <li class="page-item">
+                                            <a class="page-link" href="@Url.Action("Tools", "Admin", new { tab = "active", page = Model.CurrentPage + 1, searchTerm = Model.CurrentSearchTerm, groupId = Model.CurrentGroupId })" aria-label="Next">
+                                        <span aria-hidden="true">&gt;</span>
+                                    </a>
+                                </li>
+                    }
+                    else
+                    {
+                                <li class="page-item disabled">
+                                    <span class="page-link" aria-hidden="true">&gt;</span>
+                                </li>
                     }
                 </ul>
             </nav>
@@ -184,6 +213,20 @@
         <div class="d-flex justify-content-center">
             <nav aria-label="Disabled Tools Page navigation">
                 <ul class="pagination">
+                    @if (Model.CurrentPage > 1)
+                    {
+                                    <li class="page-item">
+                                                        <a class="page-link" href="@Url.Action("Tools", "Admin", new { tab = "disabled", page = Model.CurrentPage - 1, searchTerm = Model.CurrentSearchTerm, groupId = Model.CurrentGroupId })" aria-label="Previous">
+                                            <span aria-hidden="true">&lt;</span>
+                                        </a>
+                                    </li>
+                    }
+                    else
+                    {
+                                    <li class="page-item disabled">
+                                        <span class="page-link" aria-hidden="true">&lt;</span>
+                                    </li>
+                    }
                     @for (var i = 1; i <= Model.TotalPages; i++)
                     {
                         @if (i == Model.CurrentPage)
@@ -198,6 +241,21 @@
                                 <a class="page-link" href="@Url.Action("Tools", "Admin", new { tab = "disabled", page = i, searchTerm = Model.CurrentSearchTerm, groupId = Model.CurrentGroupId })">@i</a>
                             </li>
                         }
+                    }
+
+                    @if (Model.CurrentPage < Model.TotalPages)
+                    {
+                                    <li class="page-item">
+                                                    <a class="page-link" href="@Url.Action("Tools", "Admin", new { tab = "disabled", page = Model.CurrentPage + 1, searchTerm = Model.CurrentSearchTerm, groupId = Model.CurrentGroupId })" aria-label="Next">
+                                            <span aria-hidden="true">&gt;</span>
+                                        </a>
+                                    </li>
+                    }
+                    else
+                    {
+                                    <li class="page-item disabled">
+                                        <span class="page-link" aria-hidden="true">&gt;</span>
+                                    </li>
                     }
                 </ul>
             </nav>

--- a/PresentationLayer/Views/Search/Index.cshtml
+++ b/PresentationLayer/Views/Search/Index.cshtml
@@ -1,0 +1,106 @@
+﻿@model PresentationLayer.Models.Tool.ToolsViewModel
+@{
+    ViewData["Title"] = "Search for: " + Model.CurrentSearchTerm;
+}
+
+
+<div id="tools" class="container mt-5">
+    <div class="row mb-3">
+        <form method="get" class="d-flex gap-2">
+            <input type="text" class="form-control w-50" name="searchTerm" value="@Model.CurrentSearchTerm" placeholder="Search tools" />
+
+            <select name="groupId" class="form-select w-25">
+                <option value="0">All Groups</option>
+                @foreach (var group in Model.Groups)
+                {
+                    @if (group.GroupId == Model.CurrentGroupId)
+                    {
+                        <option value="@group.GroupId" selected>@group.GroupName</option>
+                    }
+                    else
+                    {
+                        <option value="@group.GroupId">@group.GroupName</option>
+                    }
+                }
+            </select>
+
+            <button type="submit" class="btn btn-primary">Search</button>
+        </form>
+    </div>
+    <div class="row">
+        @if (Model.Tools.Any())
+        {
+            @foreach (var tool in Model.Tools)
+            {
+                <a class="btn-light btn col-6 col-lg-4 col-xl-3 mb-4" style="text-align: left; background-color: transparent; border: none;" href="@Url.Action("Index", "Tools", new { id = tool.ToolId })">
+                    <div class="card shadow-sm" style="height: 8rem; position: relative">
+                        @if (tool.IsPremium)
+                        {
+                            <img src="/crown.png" alt="Premium" style="height: 20px; width: auto; position: absolute; top: 0.5rem; right: 0.5rem;" />
+
+                        }
+                        <div class="card-body">
+                            <h5 class="card-title line-2">@tool.Name</h5>
+                            <p class="card-text line-2">@tool.Description</p>
+                        </div>
+                    </div>
+                </a>
+            }
+            <div class="d-flex justify-content-center">
+                <nav aria-label="Active Tools Page navigation">
+                    <ul class="pagination">
+                        @if (Model.CurrentPage > 1)
+                        {
+                            <li class="page-item">
+                                <a class="page-link" href="@Url.Action("Index", "Search", new { page = Model.CurrentPage - 1, searchTerm = Model.CurrentSearchTerm, groupId = Model.CurrentGroupId })" aria-label="Previous">
+                                    <span aria-hidden="true">&lt;</span>
+                                </a>
+                            </li>
+                        }
+                        else
+                        {
+                            <li class="page-item disabled">
+                                <span class="page-link" aria-hidden="true">&lt;</span>
+                            </li>
+                        }
+
+                        @for (var i = 1; i <= Model.TotalPages; i++)
+                        {
+                            @if (i == Model.CurrentPage)
+                            {
+                                <li class="page-item active" aria-current="page">
+                                    <a class="page-link" href="@Url.Action("Index", "Search", new { page = i, searchTerm = Model.CurrentSearchTerm, groupId = Model.CurrentGroupId })">@i</a>
+                                </li>
+                            }
+                            else
+                            {
+                                <li class="page-item">
+                                    <a class="page-link" href="@Url.Action("Index", "Search", new { page = i, searchTerm = Model.CurrentSearchTerm, groupId = Model.CurrentGroupId })">@i</a>
+                                </li>
+                            }
+                        }
+
+                        @if (Model.CurrentPage < Model.TotalPages)
+                        {
+                            <li class="page-item">
+                                <a class="page-link" href="@Url.Action("Index", "Search", new { page = Model.CurrentPage + 1, searchTerm = Model.CurrentSearchTerm, groupId = Model.CurrentGroupId })" aria-label="Next">
+                                    <span aria-hidden="true">&gt;</span>
+                                </a>
+                            </li>
+                        }
+                        else
+                        {
+                            <li class="page-item disabled">
+                                <span class="page-link" aria-hidden="true">&gt;</span>
+                            </li>
+                        }
+                    </ul>
+                </nav>
+            </div>
+        }
+        else
+        {
+            <p>No tools for @Model.CurrentSearchTerm</p>
+        }
+    </div>
+</div>

--- a/PresentationLayer/Views/Shared/_Layout.cshtml
+++ b/PresentationLayer/Views/Shared/_Layout.cshtml
@@ -30,8 +30,8 @@
                     <button class="btn btn-outline-primary me-2" id="menu-toggle">
                         <i class="bi bi-list"></i>
                     </button>
-                    <form class="d-flex flex-grow-1 mx-2">
-                        <input class="form-control" type="search" placeholder="Search" aria-label="Search">
+                    <form class="d-flex flex-grow-1 mx-2" asp-action="Index" asp-controller="Search">
+                        <input name="searchTerm" class="form-control" type="search" placeholder="Search" aria-label="Search">
                     </form>
                     <partial name="_LoginPartial" />
                 </div>

--- a/PresentationLayer/Views/Shared/_ToolsMenuPartial.cshtml
+++ b/PresentationLayer/Views/Shared/_ToolsMenuPartial.cshtml
@@ -15,8 +15,13 @@
             @if (!tool.IsDisabled)
             {
                 <li class="nav-item">
-                    <a class="nav-link text-white" href="@Url.Action("Index", "Tools", new { id = tool.ToolId })">
+                    <a style="position: relative" class="nav-link text-white" href="@Url.Action("Index", "Tools", new { id = tool.ToolId })">
                         @tool.Name
+                        @if (tool.IsPremium)
+                        {
+                            <img src="/crown.png" alt="Premium" style="height: 16px; width: auto; position: absolute; top: 0.5rem; right: 0.5rem;" />
+
+                        }
                     </a>
                 </li>
             }


### PR DESCRIPTION
Add a new search view that allows users to filter tools by search 
term and group. Display results with pagination controls to navigate 
through multiple pages. Highlight premium tools with an icon and 
improve usability by preserving filter selections on page reload.