### PR TITLE
feat(user-favorites): add user favorite tools feature and access control

### DIFF
--- a/BusinessLayer/Entities/ApplicationUser.cs
+++ b/BusinessLayer/Entities/ApplicationUser.cs
@@ -10,5 +10,9 @@ namespace BusinessLayer.Entities
         public required string Name { get; set; }
         [DefaultValue("https://res.cloudinary.com/ltphat2204/image/upload/q_auto:best/f_auto/default_profile")]
         public string Photo { get; set; } = "https://res.cloudinary.com/ltphat2204/image/upload/q_auto:best/f_auto/default_profile";
+        [DefaultValue(null)]
+        public string? PremiumRequest { get; set; }
+
+        public ICollection<Tool> FavoriteTools { get; set; } = [];
     }
 }

--- a/BusinessLayer/Entities/Tool.cs
+++ b/BusinessLayer/Entities/Tool.cs
@@ -27,5 +27,7 @@ namespace BusinessLayer.Entities
         [Required]
         public int GroupId { get; set; }
         public required Group Group { get; set; }
+
+        public ICollection<ApplicationUser> FavoritedByUsers { get; set; } = [];
     }
 }

--- a/BusinessLayer/Interfaces/IUserRepository.cs
+++ b/BusinessLayer/Interfaces/IUserRepository.cs
@@ -9,5 +9,6 @@ namespace BusinessLayer.Interfaces
         Task<ApplicationUser?> GetUserByEmailAsync(string email);
         Task<SignInResult> PasswordSignInAsync(string email, string password, bool isPersistent, bool lockoutOnFailure);
         Task SignOutAsync();
+        Task<bool> IsToolFavoriteAsync(string userId, int toolId);
     }
 }

--- a/DataAccessLayer/ApplicationDbContext.cs
+++ b/DataAccessLayer/ApplicationDbContext.cs
@@ -12,6 +12,11 @@ namespace DataAccessLayer
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<ApplicationUser>()
+            .HasMany(u => u.FavoriteTools)
+            .WithMany(t => t.FavoritedByUsers)
+            .UsingEntity(j => j.ToTable("UserFavoriteTools"));
         }
     }
 }

--- a/DataAccessLayer/Migrations/20250422152044_AddUserFavoriteToolsRelationship.Designer.cs
+++ b/DataAccessLayer/Migrations/20250422152044_AddUserFavoriteToolsRelationship.Designer.cs
@@ -4,6 +4,7 @@ using DataAccessLayer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DataAccessLayer.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250422152044_AddUserFavoriteToolsRelationship")]
+    partial class AddUserFavoriteToolsRelationship
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DataAccessLayer/Migrations/20250422152044_AddUserFavoriteToolsRelationship.cs
+++ b/DataAccessLayer/Migrations/20250422152044_AddUserFavoriteToolsRelationship.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DataAccessLayer.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserFavoriteToolsRelationship : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PremiumRequest",
+                table: "AspNetUsers",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "UserFavoriteTools",
+                columns: table => new
+                {
+                    FavoriteToolsToolId = table.Column<int>(type: "int", nullable: false),
+                    FavoritedByUsersId = table.Column<string>(type: "nvarchar(450)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserFavoriteTools", x => new { x.FavoriteToolsToolId, x.FavoritedByUsersId });
+                    table.ForeignKey(
+                        name: "FK_UserFavoriteTools_AspNetUsers_FavoritedByUsersId",
+                        column: x => x.FavoritedByUsersId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_UserFavoriteTools_Tools_FavoriteToolsToolId",
+                        column: x => x.FavoriteToolsToolId,
+                        principalTable: "Tools",
+                        principalColumn: "ToolId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserFavoriteTools_FavoritedByUsersId",
+                table: "UserFavoriteTools",
+                column: "FavoritedByUsersId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserFavoriteTools");
+
+            migrationBuilder.DropColumn(
+                name: "PremiumRequest",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/DataAccessLayer/Repositories/UserRepository.cs
+++ b/DataAccessLayer/Repositories/UserRepository.cs
@@ -1,6 +1,7 @@
 ﻿using BusinessLayer.Entities;
 using BusinessLayer.Interfaces;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 
 namespace DataAccessLayer.Repositories
 {
@@ -42,6 +43,21 @@ namespace DataAccessLayer.Repositories
         public async Task SignOutAsync()
         {
             await _signInManager.SignOutAsync();
+        }
+
+        public async Task<bool> IsToolFavoriteAsync(string userId, int toolId)
+        {
+            if (string.IsNullOrEmpty(userId) || toolId <= 0)
+            {
+                return false;
+            }
+
+            bool isFavorite = await _context.Users
+                                      .Where(u => u.Id == userId)
+                                      .SelectMany(u => u.FavoriteTools) 
+                                      .AnyAsync(t => t.ToolId == toolId);
+
+            return isFavorite;
         }
     }
 }

--- a/PresentationLayer/Controllers/AdminController.cs
+++ b/PresentationLayer/Controllers/AdminController.cs
@@ -1,5 +1,6 @@
 ﻿using BusinessLayer.Entities;
 using BusinessLayer.Interfaces;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PresentationLayer.Models.Group;
 using PresentationLayer.Models.Tool;
@@ -7,6 +8,7 @@ using System.Diagnostics;
 
 namespace PresentationLayer.Controllers
 {
+    [Authorize(Roles = "Admin")]
     public class AdminController(IUnitOfWork _unitOfWork, ILogger<AuthController> logger) : Controller
     {
         public IActionResult Index()

--- a/PresentationLayer/Controllers/AuthController.cs
+++ b/PresentationLayer/Controllers/AuthController.cs
@@ -12,6 +12,12 @@ namespace PresentationLayer.Controllers
             return View();
         }
 
+        [HttpGet]
+        public IActionResult Deny()
+        {
+            return View();
+        }
+
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Login(LoginViewModel model)

--- a/PresentationLayer/Controllers/FavoritesApiController.cs
+++ b/PresentationLayer/Controllers/FavoritesApiController.cs
@@ -1,0 +1,76 @@
+﻿using BusinessLayer.Entities;
+using DataAccessLayer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace PresentationLayer.Controllers
+{
+    [Authorize]
+    [ApiController]
+    [Route("api/[controller]")]
+    public class FavoritesApiController : ControllerBase
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        public FavoritesApiController(ApplicationDbContext context, UserManager<ApplicationUser> userManager)
+        {
+            _context = context;
+            _userManager = userManager;
+        }
+
+        [HttpPost("toggle")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> ToggleFavorite([FromForm] int toolId)
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null)
+            {
+                return Unauthorized(new { success = false, message = "User not logged in." });
+            }
+
+            var tool = await _context.Tools.FindAsync(toolId);
+            if (tool == null)
+            {
+                return NotFound(new { success = false, message = "Tool not found." });
+            }
+
+            var userWithFavorites = await _context.Users
+                                                 .Include(u => u.FavoriteTools)
+                                                 .FirstOrDefaultAsync(u => u.Id == user.Id);
+
+            if (userWithFavorites == null)
+            {
+                return NotFound(new { success = false, message = "User data not found." });
+            }
+
+
+            bool isCurrentlyFavorite = userWithFavorites.FavoriteTools.Any(t => t.ToolId == toolId);
+            bool newIsFavorite;
+
+            if (isCurrentlyFavorite)
+            {
+                var toolToRemove = userWithFavorites.FavoriteTools.First(t => t.ToolId == toolId);
+                userWithFavorites.FavoriteTools.Remove(toolToRemove);
+                newIsFavorite = false;
+            }
+            else
+            {
+                userWithFavorites.FavoriteTools.Add(tool);
+                newIsFavorite = true;
+            }
+
+            try
+            {
+                await _context.SaveChangesAsync();
+                return Ok(new { success = true, isFavorite = newIsFavorite });
+            }
+            catch (DbUpdateException)
+            {
+                return StatusCode(500, new { success = false, message = "Could not update favorite status. Please try again." });
+            }
+        }
+    }
+}

--- a/PresentationLayer/Controllers/ToolsController.cs
+++ b/PresentationLayer/Controllers/ToolsController.cs
@@ -1,14 +1,31 @@
-﻿using BusinessLayer.Interfaces;
+﻿using BusinessLayer.Entities;
+using BusinessLayer.Interfaces;
+using DataAccessLayer;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using PresentationLayer.Models.Tool;
 
 namespace PresentationLayer.Controllers
 {
-    public class ToolsController(ILogger<HomeController> logger, IUnitOfWork unitOfWork) : Controller
+    public class ToolsController(ILogger<HomeController> logger, IUnitOfWork unitOfWork, UserManager<ApplicationUser> userManager) : Controller
     {
-        public IActionResult Index(int id)
+        public async Task<IActionResult> Index(int id)
         {
             var tool = unitOfWork.Tools.GetById(id);
-            return View(tool);
+            bool isFavorite = false;
+            var user = await userManager.GetUserAsync(User);
+            if (user != null)
+            {
+                isFavorite = await unitOfWork.Users.IsToolFavoriteAsync(user.Id, id);
+            }
+
+            var viewModel = new ToolDetailViewModel
+            {
+                Tool = tool,
+                IsFavorite = isFavorite
+            };
+
+            return View(viewModel);
         }
 
         public IActionResult Render(int id)

--- a/PresentationLayer/Models/Tool/ToolDetailViewModel.cs
+++ b/PresentationLayer/Models/Tool/ToolDetailViewModel.cs
@@ -1,0 +1,8 @@
+﻿namespace PresentationLayer.Models.Tool
+{
+    public class ToolDetailViewModel
+    {
+        public BusinessLayer.Entities.Tool Tool { get; set; }
+        public bool IsFavorite { get; set; }
+    }
+}

--- a/PresentationLayer/Views/Auth/Deny.cshtml
+++ b/PresentationLayer/Views/Auth/Deny.cshtml
@@ -1,0 +1,13 @@
+﻿<div class="container d-flex justify-content-center">
+    <div class="card text-center p-4" style="width: 30rem;">
+        <div class="card-header bg-danger text-white">
+            <h2>Access Denied</h2>
+        </div>
+        <div class="card-body">
+            <h4 class="card-title">You do not have permission to view this page.</h4>
+            <p class="card-text">Only users with the Admin role are allowed to access this page.</p>
+            <a href="/" class="btn btn-primary">Go to Home</a>
+        </div>
+    </div>
+</div>
+

--- a/PresentationLayer/Views/Shared/_Layout.cshtml
+++ b/PresentationLayer/Views/Shared/_Layout.cshtml
@@ -19,7 +19,7 @@
                 <div class="sidebar-heading">IT Tools</div>
             </a>
             <hr/>
-            <ul class="nav flex-column">
+            <ul class="nav flex-column" >
                 <partial name="_ToolsMenuPartial" />
             </ul>
         </div>

--- a/PresentationLayer/Views/Shared/_LoginPartial.cshtml
+++ b/PresentationLayer/Views/Shared/_LoginPartial.cshtml
@@ -47,6 +47,9 @@
                 <li class="nav-item">
                     <a class="dropdown-item" asp-controller="User" asp-action="Profile">Profile</a>
                 </li>
+                <li class="nav-item">
+                    <a class="dropdown-item" asp-controller="User" asp-action="MyFavorites">My favorites</a>
+                </li>
                 @if (User.IsInRole("Admin"))
                 {
                     <li class="nav-item">

--- a/PresentationLayer/Views/Tools/Index.cshtml
+++ b/PresentationLayer/Views/Tools/Index.cshtml
@@ -1,16 +1,33 @@
-﻿@{
-    ViewData["Title"] = Model.Name;
+﻿@model PresentationLayer.Models.Tool.ToolDetailViewModel;
+
+@{
+    ViewData["Title"] = Model.Tool.Name;
+    var antiforgeryToken = @Html.AntiForgeryToken();
 }
 
 <div class="jumbotron text-center bg-light py-5 container">
-    <h1 class="display-4">@Model.Name</h1>
-    <p class="lead">@Model.Description</p>
+    <h1 class="display-4">@Model.Tool.Name</h1>
+    <p class="lead">@Model.Tool.Description</p>
     <hr class="my-2" />
 
     <div class="d-flex align-items-center gap-2 justify-content-center">
-        <button class="btn text-danger" style="font-size: 2rem;">
-            <i class="bi bi-heart"></i>
-        </button>
+        @if (User.Identity.IsAuthenticated)
+        {
+            <button id="favorite-toggle-btn" class="btn text-danger" style="font-size: 2rem;"
+                    data-tool-id="@Model.Tool.ToolId"
+                    title="@(Model.IsFavorite ? "Bỏ thích" : "Yêu thích")">
+                <i id="favorite-icon" class="bi @(Model.IsFavorite ? "bi-heart-fill" : "bi-heart")"></i>
+            </button>
+            <form id="anti-forgery-form"> @Html.AntiForgeryToken() </form>
+        }
+        else
+        {
+            <a asp-area="Identity" asp-page="/Account/Login" asp-route-returnUrl="@Context.Request.Path"
+               class="btn text-secondary" style="font-size: 2rem;" title="Đăng nhập để yêu thích">
+                <i class="bi bi-heart"></i>
+            </a>
+        }
+
         <span class=" me-3">or share on</span>
         <a href="#" target="_blank" class="btn btn-primary">
             <i class="bi bi-facebook"></i> Facebook
@@ -23,4 +40,58 @@
 
 <hr class="my-4" />
 
-<iframe style="width: 100%; height: 100svh" src="@Url.Action("Render", "Tools", new { id = Model.ToolId })"></iframe>
+<iframe style="width: 100%; height: 100svh" src="@Url.Action("Render", "Tools", new { id = Model.Tool.ToolId })"></iframe>
+
+@section Scripts {
+    <script>
+        $(document).ready(function () {
+            $('#favorite-toggle-btn').on('click', function (e) {
+                e.preventDefault();
+
+                var $button = $(this);
+                var $icon = $('#favorite-icon');
+                var toolId = $button.data('tool-id');
+
+                var token = $('#anti-forgery-form input[name="__RequestVerificationToken"]').val();
+
+                $button.prop('disabled', true);
+
+                $.ajax({
+                    url: '/api/FavoritesApi/toggle',
+                    type: 'POST',
+                    headers: {
+                        'RequestVerificationToken': token
+                    },
+                    data: {
+                        toolId: toolId
+                    },
+                    success: function (response) {
+                        if (response.success) {
+                            if (response.isFavorite) {
+                                $icon.removeClass('bi-heart').addClass('bi-heart-fill');
+                                $button.attr('title', 'Bỏ thích');
+                            } else {
+                                $icon.removeClass('bi-heart-fill').addClass('bi-heart');
+                                 $button.attr('title', 'Yêu thích');
+                            }
+                        } else {
+                            alert(response.message || 'Có lỗi xảy ra, vui lòng thử lại.');
+                        }
+                    },
+                    error: function (jqXHR, textStatus, errorThrown) {
+                        console.error("AJAX Error:", textStatus, errorThrown, jqXHR.responseText);
+                        if (jqXHR.status === 401) {
+                            alert('Bạn cần đăng nhập để thực hiện hành động này.');
+                            window.location.href = '/Auth/Login?ReturnUrl=' + encodeURIComponent(window.location.pathname);
+                        } else {
+                            alert('Đã xảy ra lỗi kết nối. Vui lòng thử lại.');
+                        }
+                    },
+                    complete: function () {
+                        $button.prop('disabled', false);
+                    }
+                });
+            });
+        });
+    </script>
+}

--- a/PresentationLayer/Views/User/MyFavorites.cshtml
+++ b/PresentationLayer/Views/User/MyFavorites.cshtml
@@ -1,0 +1,136 @@
+﻿@model IEnumerable<BusinessLayer.Entities.Tool>
+@{
+    ViewData["Title"] = "My Favorite Tools";
+}
+
+<div id="tools" class="container mt-5">
+    <h1 class="mb-4">@ViewData["Title"]</h1>
+
+    <div class="row">
+        @if (Model.Any())
+        {
+            @foreach (var tool in Model)
+            {
+                <div class="col-6 col-lg-4 col-xl-3 mb-4 favorite-tool-card-container" id="tool-card-@tool.ToolId">
+                    <div class="card shadow-sm h-100 pt-4" style="position: relative;">
+                        <button class="btn btn-sm btn-danger remove-favorite-btn"
+                                data-tool-id="@tool.ToolId"
+                                title="Remove from favorites"
+                                style="position: absolute; top: 0.5rem; left: 0.5rem; z-index: 10; padding: 0.1rem 0.4rem; line-height: 1;">
+                            <i class="bi bi-x-lg"></i>
+                        </button>
+
+                        @if (tool.IsPremium)
+                        {
+                            <img src="/crown.png" alt="Premium" title="Premium Tool" style="height: 20px; width: auto; position: absolute; top: 0.5rem; right: 0.5rem; z-index: 10;" />
+                        }
+
+                        <a href="@Url.Action("Index", "Tools", new { id = tool.ToolId })" class="text-decoration-none text-dark d-flex flex-column h-100">
+                            <div class="card-body d-flex flex-column">
+                                <h5 class="card-title line-2">@tool.Name</h5>
+                                <p class="card-text line-2 flex-grow-1">@tool.Description</p>
+                                <p class="card-text mt-auto"><small class="text-muted">Group: @tool.Group?.GroupName</small></p>
+                            </div>
+                        </a>
+                    </div>
+                </div>
+            }
+        }
+        else
+        {
+            <div class="col-12">
+                <div class="alert alert-info" role="alert" id="no-favorites-message">
+                    You haven't added any tools to your favorites yet. <a asp-controller="Home" asp-action="Index" class="alert-link">Browse tools</a> to find some!
+                </div>
+            </div>
+        }
+    </div>
+
+    <form id="anti-forgery-form-favorites" class="d-none">@Html.AntiForgeryToken()</form>
+</div>
+
+
+@section Scripts {
+    <script>
+        $(document).ready(function () {
+            $('#tools').on('click', '.remove-favorite-btn', function (e) {
+                e.preventDefault();
+                e.stopPropagation();
+
+                var $button = $(this);
+                var toolId = $button.data('tool-id');
+                var token = $('#anti-forgery-form-favorites input[name="__RequestVerificationToken"]').val();
+                var $cardContainer = $button.closest('.favorite-tool-card-container');
+                var toolName = $cardContainer.find('.card-title').text().trim();
+
+                if (!toolId || !token) {
+                    console.error("Missing toolId or token for remove favorite action.");
+                    alert("An error occurred. Please refresh the page and try again.");
+                    return;
+                }
+
+                if (!confirm(`Are you sure you want to remove "${toolName}" from your favorites?`)) {
+                    return;
+                }
+
+                $button.prop('disabled', true).addClass('opacity-50');
+
+                $.ajax({
+                    url: '/api/FavoritesApi/toggle',
+                    type: 'POST',
+                    headers: {
+                        'RequestVerificationToken': token
+                    },
+                    data: {
+                        toolId: toolId
+                    },
+                    success: function (response) {
+                        if (response.success && !response.isFavorite) { 
+                            $cardContainer.fadeOut(400, function() {
+                                $(this).remove();
+                                if ($('.favorite-tool-card-container').length === 0) {
+                                     if ($('#no-favorites-message').length === 0) {
+                                         $('#tools .row').html(
+                                             '<div class="col-12">' +
+                                             '<div class="alert alert-info" role="alert" id="no-favorites-message">' +
+                                             'You haven\'t added any tools to your favorites yet. <a href="/" class="alert-link">Browse tools</a> to find some!' +
+                                             '</div>' +
+                                             '</div>'
+                                         );
+                                     }
+
+                                     $('#no-favorites-message').parent().show(); 
+                                }
+                            });
+                        } else {
+                            console.error("Remove favorite failed or state mismatch:", response.message);
+                            alert(response.message || 'Could not remove the tool from favorites. Please try again.');
+                             $button.prop('disabled', false).removeClass('opacity-50');
+                        }
+                    },
+                    error: function (jqXHR, textStatus, errorThrown) {
+                        console.error("AJAX Error removing favorite:", textStatus, errorThrown, jqXHR.responseText);
+                        let errorMessage = 'An error occurred while communicating with the server.';
+                         if (jqXHR.status === 401) {
+                             errorMessage = 'Your session may have expired. Please log in again.';
+                         } else if (jqXHR.responseJSON && jqXHR.responseJSON.message) {
+                             errorMessage = jqXHR.responseJSON.message;
+                         }
+                        alert(errorMessage);
+                         $button.prop('disabled', false).removeClass('opacity-50');
+                    }
+                });
+            });
+        });
+    </script>
+    <style>
+        .remove-favorite-btn {
+            opacity: 0.7;
+            transition: opacity 0.2s ease-in-out;
+        }
+
+        .card:hover .remove-favorite-btn {
+            opacity: 1;
+        }
+    </style>
+}


### PR DESCRIPTION
Add a new UserFavoriteTools join table to track users' favorite tools.
Implement MyFavorites action in UserController to display user's favorites.
Protect UserController with authorization to restrict access to authenticated users.
Fix iframe src in Tools index view to correctly reference ToolId.
Add client-side script to toggle favorite status via AJAX with UI feedback.
Create an Access Denied view to inform users without admin role of restricted pages.
Add PremiumRequest property to ApplicationUser entity for future use.