### PR TITLE
feat(premium): add premium request feature for users and admin

### DIFF
--- a/PresentationLayer/Controllers/ToolsController.cs
+++ b/PresentationLayer/Controllers/ToolsController.cs
@@ -12,17 +12,27 @@ namespace PresentationLayer.Controllers
         public async Task<IActionResult> Index(int id)
         {
             var tool = unitOfWork.Tools.GetById(id);
+            if (tool == null || tool.IsDisabled)
+            {
+                return NotFound();
+            }
+
             bool isFavorite = false;
             var user = await userManager.GetUserAsync(User);
+
+            bool isBlocked = tool.IsPremium;
             if (user != null)
             {
                 isFavorite = await unitOfWork.Users.IsToolFavoriteAsync(user.Id, id);
+                var roles = await userManager.GetRolesAsync(user);
+                isBlocked = tool.IsPremium && !roles.Contains("Premium");
             }
 
             var viewModel = new ToolDetailViewModel
             {
                 Tool = tool,
-                IsFavorite = isFavorite
+                IsFavorite = isFavorite,
+                IsBlock = isBlocked
             };
 
             return View(viewModel);

--- a/PresentationLayer/Models/Tool/ToolDetailViewModel.cs
+++ b/PresentationLayer/Models/Tool/ToolDetailViewModel.cs
@@ -4,5 +4,6 @@
     {
         public BusinessLayer.Entities.Tool Tool { get; set; }
         public bool IsFavorite { get; set; }
+        public bool IsBlock { get; set; } = false;
     }
 }

--- a/PresentationLayer/Models/User/PremiumRequestViewModel.cs
+++ b/PresentationLayer/Models/User/PremiumRequestViewModel.cs
@@ -1,0 +1,12 @@
+﻿using BusinessLayer.Entities;
+
+namespace PresentationLayer.Models.User
+{
+    public class PremiumRequestViewModel
+    {
+        public List<ApplicationUser> Users { get; set; }
+        public int TotalUsers { get; set; }
+        public int CurrentPage { get; set; }
+        public int PageSize { get; set; }
+    }
+}

--- a/PresentationLayer/Models/User/UpdateProfileViewModel.cs
+++ b/PresentationLayer/Models/User/UpdateProfileViewModel.cs
@@ -6,6 +6,8 @@
         public string Name { get; set; }
         public string Email { get; set; }
         public IFormFile? NewImage { get; set; } 
-        public string? ImageUrl { get; set; } 
+        public string? ImageUrl { get; set; }
+        public string? PremiumRequest { get; set; }
+        public bool IsPremium { get; set; }
     }
 }

--- a/PresentationLayer/Models/User/UserListViewModel.cs
+++ b/PresentationLayer/Models/User/UserListViewModel.cs
@@ -1,0 +1,15 @@
+﻿using BusinessLayer.Entities;
+
+namespace PresentationLayer.Models.User
+{
+    public class UserListViewModel
+    {
+        public IEnumerable<ApplicationUser> Users { get; set; }
+        public int TotalUsers { get; set; }
+        public int CurrentPage { get; set; }
+        public int PageSize { get; set; }
+        public string SearchQuery { get; set; }
+        public string RoleFilter { get; set; }
+        public string[] Roles { get; set; }
+    }
+}

--- a/PresentationLayer/Views/Admin/PremiumRequests.cshtml
+++ b/PresentationLayer/Views/Admin/PremiumRequests.cshtml
@@ -1,0 +1,56 @@
+﻿@model PresentationLayer.Models.User.PremiumRequestViewModel
+
+@{
+    ViewData["Title"] = "Premium Requests";
+    Layout = "~/Views/Shared/_AdminLayout.cshtml";
+}
+
+<div class="container mt-5">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th>User ID</th>
+                <th>Name</th>
+                <th>Email</th>
+                <th>Premium Request</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var user in Model.Users)
+            {
+                <tr>
+                    <td>@user.Id</td>
+                    <td>@user.Name</td>
+                    <td>@user.Email</td>
+                    <td>@user.PremiumRequest</td>
+                    <td>
+                        <!-- Approve button -->
+                        <form method="post" action="@Url.Action("ApprovePremiumRequest", "Admin")" style="display:inline;">
+                            <input type="hidden" name="userId" value="@user.Id" />
+                            <button type="submit" class="btn btn-success">Approve</button>
+                        </form>
+
+                        <!-- Reject button -->
+                        <form method="post" action="@Url.Action("RejectPremiumRequest", "Admin")" style="display:inline;">
+                            <input type="hidden" name="userId" value="@user.Id" />
+                            <button type="submit" class="btn btn-danger">Reject</button>
+                        </form>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+
+    <!-- Pagination -->
+    <nav>
+        <ul class="pagination">
+            @for (var i = 1; i <= (Model.TotalUsers / Model.PageSize); i++)
+            {
+                <li class="page-item @(Model.CurrentPage == i ? "active" : "")">
+                    <a class="page-link" href="@Url.Action("PremiumRequests", new { page = i })">@i</a>
+                </li>
+            }
+        </ul>
+    </nav>
+</div>

--- a/PresentationLayer/Views/Admin/Users.cshtml
+++ b/PresentationLayer/Views/Admin/Users.cshtml
@@ -1,0 +1,186 @@
+﻿@model PresentationLayer.Models.User.UserListViewModel
+@using Microsoft.AspNetCore.Identity
+@using BusinessLayer.Entities
+@inject UserManager<ApplicationUser> UserManager
+
+@{
+    ViewData["Title"] = "Users";
+    Layout = "~/Views/Shared/_AdminLayout.cshtml";
+}
+
+<div class="container mt-5">
+    <!-- Search and filter -->
+    <form method="get" class="d-flex gap-2">
+        <input class="form-control w-50" type="text" name="search" value="@Model.SearchQuery" placeholder="Search by name or email" />
+        <select name="roleFilter" class="form-select w-25">
+            @if (@Model.RoleFilter == "All")
+            {
+                <option value="All" selected>All Roles</option>
+            }
+            else
+            {
+                <option value="All">All Roles</option>
+            }
+            @if (@Model.RoleFilter == "User")
+            {
+                <option value="User" selected>User</option>
+            }
+            else
+            {
+                <option value="User">User</option>
+            }
+            @if (@Model.RoleFilter == "Admin")
+            {
+                <option value="Admin" selected>Admin</option>
+            }
+            else
+            {
+                <option value="Admin">Admin</option>
+            }
+        </select>
+        <button type="submit" class="btn btn-primary">Search</button>
+    </form>
+
+    <!-- User table -->
+    <table class="table table-bordered table-striped mt-3">
+        <thead>
+            <tr>
+                <th>User ID</th>
+                <th>Name</th>
+                <th>Email</th>
+                <th>Role</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var user in Model.Users)
+            {
+                var roles = await @UserManager.GetRolesAsync(user);
+                var role = roles.FirstOrDefault() ?? "User";
+                <tr>
+                    <td>@user.Id</td>
+                    <td>@user.Name</td>
+                    <td>@user.Email</td>
+                    <td>@role</td>
+                    <td>
+                        <!-- Edit button -->
+                        <button class="btn btn-warning" data-bs-toggle="modal" data-bs-target="#editUserModal" data-id="@user.Id" data-name="@user.Name" data-email="@user.Email">
+                            Edit
+                        </button>
+
+                        <!-- Role Change -->
+                        @if (role == "Premium")
+                        {
+                            <form method="post" action="@Url.Action("ChangeRole", "Admin")" style="display:inline;">
+                                <input type="hidden" name="userId" value="@user.Id" />
+                                <input type="hidden" name="newRole" value="User" />
+                                <button type="submit" class="btn btn-primary">Downgrade to User</button>
+                            </form>
+                        }
+                        @if (role == "User")
+                        {
+                            <form method="post" action="@Url.Action("ChangeRole", "Admin")" style="display:inline;">
+                                <input type="hidden" name="userId" value="@user.Id" />
+                                <input type="hidden" name="newRole" value="Premium" />
+                                <button type="submit" class="btn btn-success">Upgrade to Premium</button>
+                            </form>
+                        }
+                        
+                        <!-- Delete button -->
+                        <button class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#deleteUserModal" data-id="@user.Id" data-name="@user.Name">
+                            Delete
+                        </button>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+
+    <!-- Pagination -->
+    <nav class="d-flex justify-content-center">
+        <ul class="pagination">
+            @for (var i = 1; i <= (Model.TotalUsers / Model.PageSize); i++)
+            {
+                <li class="page-item @(Model.CurrentPage == i ? "active" : "")">
+                    <a class="page-link" href="@Url.Action("Index", new { page = i, search = Model.SearchQuery, roleFilter = Model.RoleFilter })">@i</a>
+                </li>
+            }
+        </ul>
+    </nav>
+</div>
+
+<!-- Edit User Modal -->
+<div class="modal fade" id="editUserModal" tabindex="-1" aria-labelledby="editUserModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="editUserModalLabel">Edit User</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <form method="post" action="@Url.Action("EditUser", "Admin")">
+                <div class="modal-body">
+                    <input type="hidden" id="EditUserId" name="UserId" />
+                    <div class="form-group">
+                        <label for="EditUserName">User Name</label>
+                        <input type="text" class="form-control" id="EditUserName" name="Name" required />
+                    </div>
+                    <div class="form-group">
+                        <label for="EditUserEmail">Email</label>
+                        <input type="email" class="form-control" id="EditUserEmail" name="Email" required />
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Save Changes</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<!-- Delete User Modal -->
+<div class="modal fade" id="deleteUserModal" tabindex="-1" aria-labelledby="deleteUserModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="deleteUserModalLabel">Delete User</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <form method="post" action="@Url.Action("DeleteUser", "Admin")">
+                <div class="modal-body">
+                    <input type="hidden" id="DeleteUserId" name="UserId" />
+                    <p>Are you sure you want to delete the user <strong><span id="DeleteUserName"></span></strong>?</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-danger">Delete</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<script>
+    $('#editUserModal').on('show.bs.modal', function (event) {
+        var button = $(event.relatedTarget);
+        var userId = button.data('id');
+        var userName = button.data('name');
+        var userEmail = button.data('email');
+
+        var modal = $(this);
+        modal.find('.modal-body #EditUserId').val(userId);
+        modal.find('.modal-body #EditUserName').val(userName);
+        modal.find('.modal-body #EditUserEmail').val(userEmail);
+    });
+
+    $('#deleteUserModal').on('show.bs.modal', function (event) {
+        var button = $(event.relatedTarget);
+        var userId = button.data('id');
+        var userName = button.data('name');
+
+        var modal = $(this);
+        modal.find('.modal-body #DeleteUserId').val(userId);
+        modal.find('.modal-body #DeleteUserName').text(userName);
+    });
+
+</script>

--- a/PresentationLayer/Views/Shared/_AdminLayout.cshtml
+++ b/PresentationLayer/Views/Shared/_AdminLayout.cshtml
@@ -9,6 +9,8 @@
     <link rel="stylesheet" href="~/PresentationLayer.styles.css" asp-append-version="true" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css" />
     <script src="~/lib/jquery/dist/jquery.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11.19.1/dist/sweetalert2.all.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/sweetalert2@11.19.1/dist/sweetalert2.min.css">
 </head>
 <body class="bg-light">
     <div id="wrapper">
@@ -19,12 +21,12 @@
             <hr/>
             <ul class="nav flex-column">
                 <li class="nav-item">
-                    <a class="nav-link text-white" href="#">
-                        <i class="bi bi-bar-chart-line-fill me-2"></i> Dashboard
+                    <a class="nav-link text-white" asp-controller="Admin" asp-action="PremiumRequests">
+                        <i class="bi bi-bar-chart-line-fill me-2"></i> Premium Requests
                     </a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link text-white" href="#">
+                    <a class="nav-link text-white" asp-controller="Admin" asp-action="Users">
                         <i class="bi bi-people-fill me-2"></i> Users
                     </a>
                 </li>

--- a/PresentationLayer/Views/Shared/_Layout.cshtml
+++ b/PresentationLayer/Views/Shared/_Layout.cshtml
@@ -7,7 +7,10 @@
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/PresentationLayer.styles.css" asp-append-version="true" />
+    <script src="~/lib/jquery/dist/jquery.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css" />
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11.19.1/dist/sweetalert2.all.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/sweetalert2@11.19.1/dist/sweetalert2.min.css">
 </head>
 <body class="bg-light">
     <div id="wrapper">
@@ -46,7 +49,6 @@
             </div>
         </div>
     </div>
-    <script src="~/lib/jquery/dist/jquery.min.js"></script>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
     <script>

--- a/PresentationLayer/Views/Tools/Index.cshtml
+++ b/PresentationLayer/Views/Tools/Index.cshtml
@@ -14,16 +14,16 @@
         @if (User.Identity.IsAuthenticated)
         {
             <button id="favorite-toggle-btn" class="btn text-danger" style="font-size: 2rem;"
-                    data-tool-id="@Model.Tool.ToolId"
-                    title="@(Model.IsFavorite ? "Bỏ thích" : "Yêu thích")">
+            data-tool-id="@Model.Tool.ToolId"
+            title="@(Model.IsFavorite ? "Bỏ thích" : "Yêu thích")">
                 <i id="favorite-icon" class="bi @(Model.IsFavorite ? "bi-heart-fill" : "bi-heart")"></i>
             </button>
             <form id="anti-forgery-form"> @Html.AntiForgeryToken() </form>
         }
         else
         {
-            <a asp-area="Identity" asp-page="/Account/Login" asp-route-returnUrl="@Context.Request.Path"
-               class="btn text-secondary" style="font-size: 2rem;" title="Đăng nhập để yêu thích">
+            <a asp-controller="Auth" asp-action="Login" asp-route-returnUrl="@Context.Request.Path"
+            class="btn text-secondary" style="font-size: 2rem;" title="Đăng nhập để yêu thích">
                 <i class="bi bi-heart"></i>
             </a>
         }
@@ -40,7 +40,15 @@
 
 <hr class="my-4" />
 
-<iframe style="width: 100%; height: 100svh" src="@Url.Action("Render", "Tools", new { id = Model.Tool.ToolId })"></iframe>
+@if (Model.IsBlock)
+{
+    <div class="alert alert-warning">
+        <strong>Notice:</strong> This tool is available for premium users only. Please <a href="@Url.Action("Profile", "User")">upgrade to premium</a> to use this tool.
+    </div>
+} else
+{
+    <iframe style="width: 100%; height: 100svh" src="@Url.Action("Render", "Tools", new { id = Model.Tool.ToolId })"></iframe>
+}
 
 @section Scripts {
     <script>

--- a/PresentationLayer/Views/User/Profile.cshtml
+++ b/PresentationLayer/Views/User/Profile.cshtml
@@ -1,6 +1,23 @@
 ﻿@using PresentationLayer.Models.User
 @model UpdateProfileViewModel
 
+<div class="container mt-3">
+    @if (Model.PremiumRequest == "Approved")
+    {
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            Your premium request has been approved!
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
+    @if (Model.PremiumRequest == "Rejected")
+    {
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            Your premium request has been rejected.
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
+</div>
+
 <div class="p-4 row container mx-auto">
     <div class="col">
         @using (Html.BeginForm("UpdateProfile", "User", FormMethod.Post, new { enctype = "multipart/form-data" }))
@@ -34,8 +51,66 @@
                 <small class="form-text text-muted">Your email cannot be changed.</small>
             </div>
 
+            @if (Model.IsPremium)
+            {
+                <span class="badge bg-success mb-3">Premium</span>
+            }
+
             <button type="submit" class="btn btn-primary w-100 mb-3">Save Changes</button>
             <button type="button" class="btn btn-outline-secondary w-100">Change Password</button>
+
+            @if (Model.PremiumRequest == "Pending")
+            {
+                <button id="requestPremiumBtn" class="btn btn-warning w-100 mt-3" disabled>
+                    Your request is being processed
+                </button>
+            }
+            else if (Model.PremiumRequest != "Approved")
+            {
+                <button id="requestPremiumBtn" class="btn btn-warning w-100 mt-3">Request Premium</button>
+            }
         }
     </div>
 </div>
+
+<script>
+    $(document).ready(function () {
+        $('#requestPremiumBtn').click(function (e) {
+            e.preventDefault();
+            $.ajax({
+                url: '@Url.Action("RequestPremium", "User")',
+                type: 'POST',
+                data: {
+                    __RequestVerificationToken: $('input[name="__RequestVerificationToken"]').val()
+                },
+                success: function (response) {
+                    if (response === "Premium request has been submitted successfully.") {
+                        Swal.fire({
+                            icon: 'success',
+                            title: 'Request Submitted',
+                            text: 'Your premium request has been submitted successfully!',
+                            confirmButtonText: 'Ok'
+                        });
+                        $('#requestPremiumBtn').attr('disabled', true);
+                        $('#requestPremiumBtn').text('Your request is being processed');
+                    } else {
+                        Swal.fire({
+                            icon: 'error',
+                            title: 'Error',
+                            text: response,
+                            confirmButtonText: 'Ok'
+                        });
+                    }
+                },
+                error: function (xhr, status, error) {
+                    Swal.fire({
+                        icon: 'error',
+                        title: 'Error',
+                        text: 'There was an issue submitting the request: ' + error,
+                        confirmButtonText: 'Ok'
+                    });
+                }
+            });
+        });
+    });
+</script>


### PR DESCRIPTION
Add a new admin view to list and manage user premium requests with approve
and reject actions. Update user profile view to display premium status and
allow users to submit premium requests via AJAX with feedback modals. Introduce
PremiumRequestViewModel to support the new functionality. This enables a smooth
workflow for premium subscription requests and administration.