### PR TITLE
fix(admin): update user roles and role display logic

### DIFF
--- a/PresentationLayer/Controllers/AdminController.cs
+++ b/PresentationLayer/Controllers/AdminController.cs
@@ -356,9 +356,10 @@ namespace PresentationLayer.Controllers
             if (!roles.Contains("Premium"))
             {
                 await userManager.AddToRoleAsync(user, "Premium");
+                await userManager.RemoveFromRoleAsync(user, "User");
             }
 
-                user.PremiumRequest = "Approved";
+            user.PremiumRequest = "Approved";
             await userManager.UpdateAsync(user);
 
             return RedirectToAction("PremiumRequests");

--- a/PresentationLayer/Views/Admin/Users.cshtml
+++ b/PresentationLayer/Views/Admin/Users.cshtml
@@ -56,7 +56,7 @@
             @foreach (var user in Model.Users)
             {
                 var roles = await @UserManager.GetRolesAsync(user);
-                var role = roles.FirstOrDefault() ?? "User";
+                var role = roles[0];
                 <tr>
                     <td>@user.Id</td>
                     <td>@user.Name</td>


### PR DESCRIPTION
Remove "User" role when adding "Premium" role to ensure role
consistency. Change role display logic to use the first role directly
instead of defaulting to "User" to reflect actual user roles more
accurately. These changes improve role management and UI correctness.