### PR TITLE
fix: clear PremiumRequest and update user after role removal

### DIFF
--- a/PresentationLayer/Controllers/AdminController.cs
+++ b/PresentationLayer/Controllers/AdminController.cs
@@ -309,6 +309,9 @@ namespace PresentationLayer.Controllers
                 await userManager.RemoveFromRoleAsync(user, "Premium");
             }
 
+            user.PremiumRequest = null;
+            await userManager.UpdateAsync(user);
+
             return RedirectToAction("Users");
         }
 


### PR DESCRIPTION
Reset the PremiumRequest property to null and update the user
entity after removing the "Premium" role. This ensures the user's
premium request status is properly cleared and persisted in the
database.