### PR TITLE
fix(security): remove lockout settings from identity options

### DIFF
--- a/PresentationLayer/Program.cs
+++ b/PresentationLayer/Program.cs
@@ -48,11 +48,6 @@ builder.Services.Configure<IdentityOptions>(options =>
     options.Password.RequireUppercase = false;
     options.Password.RequireNonAlphanumeric = false;
 
-    // Lockout settings.
-    options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(5);
-    options.Lockout.MaxFailedAccessAttempts = 5;
-    options.Lockout.AllowedForNewUsers = true;
-
     // User settings.
     options.User.AllowedUserNameCharacters =
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@";


### PR DESCRIPTION
Remove lockout configuration including default lockout timespan,
max failed access attempts, and allowance for new users. This change
simplifies the password policy and disables account lockout to reduce
potential user friction during authentication.